### PR TITLE
Implementing the user login interface on the frontend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "react-dom": "^18.2.0",
         "react-redux": "^8.0.2",
         "react-router-dom": "^6.3.0",
-        "react-scripts": "5.0.1",
+        "react-scripts": "^5.0.1",
         "redux": "^4.2.0",
         "styled-components": "^5.3.5",
         "web-vitals": "^2.1.4"
@@ -19627,6 +19627,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
       "integrity": "sha512-8VAmEm/ZAwQzJ+GOMLbBsTdDKOpuZh7RPs0UymvBR2vRk4iZWCskjbFnxqjrzoIvlNNRZ3QJFx6/qDSi6zSnaQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.2",
     "react-router-dom": "^6.3.0",
-    "react-scripts": "5.0.1",
+    "react-scripts": "^5.0.1",
     "redux": "^4.2.0",
     "styled-components": "^5.3.5",
     "web-vitals": "^2.1.4"

--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -1,0 +1,109 @@
+import { Button, Stack, Box } from "@mui/material";
+import { getMessage } from "../services/MessageService";
+import {TextField } from "@mui/material";
+import { useState } from "react";
+
+const LoginForm = () => {
+    
+    //states used for storing and changing user login data and for defining error messages
+    const [userEmail, setUserEmail] = useState("");
+    const [password, setPassword]  = useState("");
+    const [messageEmail, setMessageEmail] = useState("");
+    const [messagePassword, setMessagePassword] = useState("");
+
+    //function that receives the form data and exibits them in the console
+    const handleSubmit = (event) => {
+        //prevents the page from reload
+        event.preventDefault();
+
+        console.log(userEmail);
+        console.log(password);
+    }
+
+    //defines what is considered an valid email address
+    const isEmail = () => /^[A-Z0-9._+-]+@[A-Z0-9-]+\.[A-Z]{2,4}$/i.test(userEmail);
+
+    //function to check if the user filled in the email input and the if the email address is valid
+    const validateEmail = () => {
+
+        //checks if the user filled in the email input
+        if(userEmail === "") {
+            setMessageEmail(getMessage('login.email.empty'));
+
+        } else{
+            setMessageEmail("");
+            //checks if the email address is valid
+            if(isEmail(userEmail) && !/[._+-]/.test(userEmail[0])) {
+                setMessageEmail("");
+            } else {
+                setMessageEmail(getMessage('login.email.error.message'));
+            }
+        }
+    }
+
+    //function to check if the user filled in the password input
+    const validatePassword = () => {
+        if(password === "") {
+            setMessagePassword(getMessage('login.password.empty'));
+        }
+        else {
+            setMessagePassword("");
+        }
+    }
+
+    return(
+        <Stack sx={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    textAlign: 'center'
+                }}>
+            
+            {/*form*/}            
+            <Box component="form" autoComplete="off" sx={{
+                    display: 'inherit',
+                    flexDirection: 'inherit',
+                    alignItems: 'flex-start',
+                    justifyContent: 'justify',
+                    textAlign: 'justify',
+                }} onSubmit={handleSubmit}>
+                    <Box sx={{display: 'inherit', flexDirection: 'inherit', mb: 3}}>
+                        <TextField
+                        label={getMessage('login.label.email')}
+                        id="email" 
+                        name="email"  
+                        type="text" 
+                        onChange={(e) => setUserEmail(e.target.value)} 
+                        onBlur={validateEmail}
+                        helperText={messageEmail}
+                        error={messageEmail !== ""}
+                        required />
+                    </Box>
+                    
+                    <Box sx={{display: 'inherit', flexDirection: 'inherit', mb: 3}}>
+                        <TextField
+                        label={getMessage('login.label.password')}
+                        id="password" 
+                        name="password"  
+                        type="password" 
+                        onChange={(e) => setPassword(e.target.value)} 
+                        onBlur={validatePassword}
+                        helperText={messagePassword}
+                        error={messagePassword !== ""}
+                        required />
+                    </Box>
+                    <Button type="submit" variant="contained" sx={{
+                        backgroundColor: 'primary.main',
+                        '&:hover':{
+                            cursor: 'pointer',
+                            backgroundColor: 'primary.light',
+                        },
+                        alignSelf: 'center'
+                    }}>{getMessage('login.button.content')}</Button>
+            </Box>
+        </Stack>        
+    );
+}
+
+export default LoginForm;

--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -100,7 +100,8 @@ const LoginForm = () => {
                             backgroundColor: 'primary.light',
                         },
                         alignSelf: 'center'
-                    }}>{getMessage('login.button.content')}</Button>
+                    }}
+                    disabled={messageEmail!=="" || messagePassword!==""}>{getMessage('login.button.content')}</Button>
             </Box>
         </Stack>        
     );

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -27,6 +27,7 @@ const Login = () => {
             minHeight: '500px',
             minWidth: '400px',
             mt: '40px',
+            mb: '40px',
             boxShadow: 4,
             p: '5px',
         }}>

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -1,0 +1,67 @@
+import Logo from '../static/images/logo.png';
+import {Box, Stack, Typography, Button} from '@mui/material';
+import { getMessage } from '../services/MessageService';
+import LoginForm from '../components/LoginForm';
+import { useNavigate } from 'react-router-dom';
+
+const Login = () => {
+    const navigateTo = useNavigate();
+
+    return (
+    <Stack sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        textAlign: 'center',
+        justifyContent: 'justify',
+    }}>
+        <Box sx={{
+            display: 'inherit',
+            flexDirection: 'inherit',
+            alignItems: 'center',
+            textAlign: 'center',
+            justifyContent: 'justify',
+            borderColor: '#cfd1d1',
+            borderRadius: '10px',
+            backgroundColor: '#fcfcfc',
+            minHeight: '500px',
+            minWidth: '400px',
+            mt: '40px',
+            boxShadow: 4,
+            p: '5px',
+        }}>
+            {/* form title */}
+            <Typography variant='h4' component='h4' sx={{
+                color: 'primary.main',
+                mt: 8,
+                mb: 6,
+                fontWeight: 'bold'
+            }}>
+                {getMessage('login.title')}
+            </Typography>
+
+            {/* form */}
+            <LoginForm />
+
+            {/* link to the ‘/register’ page */}
+            <Button onClick={() => {navigateTo('/register')}}  variant="text" size="small" 
+            sx={{
+                cursor: 'pointer', 
+                m: 5, 
+                '&:hover': {
+                    cursor: 'pointer',
+                    color: 'primary.light'
+            }}}>
+                <Typography variant='h6' component='div'>
+                    {getMessage('login.user.not.registered')}
+                </Typography>
+            </Button>
+            <Box sx={{mb: 5}}>
+                 <img src={Logo} alt="olATCG's logo" width={90} height={90} />
+            </Box>    
+        </Box>
+    </Stack>
+    );    
+}
+
+export default Login; 

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -1,5 +1,4 @@
-import Logo from '../static/images/logo.png';
-import {Box, Stack, Typography, Button} from '@mui/material';
+import {Box, Stack, Typography, Link} from '@mui/material';
 import { getMessage } from '../services/MessageService';
 import LoginForm from '../components/LoginForm';
 import { useNavigate } from 'react-router-dom';
@@ -45,21 +44,18 @@ const Login = () => {
             <LoginForm />
 
             {/* link to the ‘/register’ page */}
-            <Button onClick={() => {navigateTo('/register')}}  variant="text" size="small" 
+            <Link underline='hover' component='button' onClick={() => {navigateTo('/register')}}
             sx={{
                 cursor: 'pointer', 
                 m: 5, 
+                fontWeight: 'bold',
                 '&:hover': {
                     cursor: 'pointer',
-                    color: 'primary.light'
             }}}>
-                <Typography variant='h6' component='div'>
+                <Typography variant='p' component='p'>
                     {getMessage('login.user.not.registered')}
                 </Typography>
-            </Button>
-            <Box sx={{mb: 5}}>
-                 <img src={Logo} alt="olATCG's logo" width={90} height={90} />
-            </Box>    
+            </Link>    
         </Box>
     </Stack>
     );    

--- a/src/pages/Register.js
+++ b/src/pages/Register.js
@@ -1,0 +1,5 @@
+const Register = () => {
+    return <h1>Register</h1>;
+};
+
+export default Register;

--- a/src/routes/AppRoutes.js
+++ b/src/routes/AppRoutes.js
@@ -12,6 +12,8 @@ import { PhylogeneticTreeAnalysis } from '../pages/PhylogeneticTreeAnalysis';
 import { AlignmentAnalysisDetails } from '../pages/AlignmentAnalysisDetails';
 import { HomologyAnalysisDetails } from '../pages/HomologyAnalysisDetails';
 import PhyloTree from '../pages/PhyloTree';
+import Login from '../pages/Login';
+import Register from '../pages/Register';
 
 export default function AppRoutes(){
     return (
@@ -19,6 +21,8 @@ export default function AppRoutes(){
             <Route path="home" element={<Home />} />
             <Route path="learn" element={<Learn />} />
             <Route path="tutorials" element={<Tutorials />} />
+            <Route path="login" element={<Login />} />
+            <Route path="register" element={<Register />} />
             <Route path="tool" element={<Tools />}>
                 <Route path="alignment" element={<Alignment />} />
                 <Route path="homology" element={<Homology />} />

--- a/src/services/MessageService.js
+++ b/src/services/MessageService.js
@@ -59,6 +59,17 @@ var data_en = {
     'home.collaboration.title'                  : 'Collaboration',
     'home.collaboration.description'            : 'OLATCG is a collaborative project between',
 
+    /**LOGIN */
+    'login.title'                               :  'Log into OLATCG',
+    'login.button.content'                      :  'Login',
+    'login.user.not.registered'                 :  'New to OLATCG? Register here',
+    'login.label.email'                         :  'Email',
+    'login.label.password'                      :  'Password',
+    'login.email.error.message'                 :  'Invalid email',
+    'login.email.empty'                         :  'Enter your email address',
+    'login.password.empty'                      :  'Enter your password',
+
+    
     /** TOOLS */
     'tools.title'                               : 'Tools',
     'tools.card.alignment.title'                : 'Alignment',
@@ -350,6 +361,16 @@ var data = {
 
     'home.collaboration.title'                  : 'Colaboração',
     'home.collaboration.description'            : 'OLATCG é uma colaboração entre',
+
+    /**LOGIN */
+    'login.title'                               :  'Entre no OLATCG',
+    'login.button.content'                      :  'Login',
+    'login.user.not.registered'                 :  'Novo no OLATCG? Cadastre-se',
+    'login.label.email'                         :  'Email',
+    'login.label.password'                      :  'Senha',
+    'login.email.error.message'                 :  'Email inválido',
+    'login.email.empty'                         :  'Preencha o email',
+    'login.password.empty'                      :  'Preencha a senha',
 
     /** TOOLS */
     'tools.title'                               : 'Ferramentas',


### PR DESCRIPTION
# User Login - Frontend

## **Context**
Currently, on **OLATCG**, we do not store any user information.  
This prevents us from identifying who performed the analyses and causes **all users to have access to all analyses** in the system.
We need to address this scenario so that each user can only view **their own analyses and experiments**.

## **About the code**
- In order to fulfill the purpose presented above, an user login frontend interface was created using the components provided by the React library **Material UI**;
- The login form consists of two input areas: email and password. The email field is validated on blur, and it checks if the email follows the format **[A-Z0-9._+-]+@[A-Z0-9-]+\.[A-Z]{2,4}**. If not, an error message is displayed indicating that the email is not valid;
- Considering that at this stage is not necessary to integrate with the backend, the user is able to see the data submitted in the console. In addition to that, an **event.preventDefault()** comand was used in order to prevent the page from reloading;
- If the user is not registered to the website, it's possible to be redirected to the register page by clicking the link below the submit button. Considering the need for a route in order to use **"useNavigate" from react-router-dom**, a simple register page was created. The mentioned page consists in a simple export default function containing a h1 tag; 
- At this moment, the user is able to access the login interface by "{{domain/login}}";
- In order to prevent the user from submiting the form with an invalid email, the submit button is disabled if the email isn't valid or if the email or password input is empty. 