### PR TITLE
Implementing the user registration page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,9 +23,10 @@
         "react-dom": "^18.2.0",
         "react-redux": "^8.0.2",
         "react-router-dom": "^6.3.0",
-        "react-scripts": "5.0.1",
+        "react-scripts": "^5.0.1",
         "redux": "^4.2.0",
         "styled-components": "^5.3.5",
+        "validator": "^13.15.0",
         "web-vitals": "^2.1.4"
       }
     },
@@ -19627,6 +19628,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
       "integrity": "sha512-8VAmEm/ZAwQzJ+GOMLbBsTdDKOpuZh7RPs0UymvBR2vRk4iZWCskjbFnxqjrzoIvlNNRZ3QJFx6/qDSi6zSnaQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
@@ -21575,6 +21577,15 @@
       "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.0.tgz",
+      "integrity": "sha512-36B2ryl4+oL5QxZ3AzD0t5SsMNGvTtQHpjgFO5tbNxfXbMFkY822ktCDe1MnlqV3301QQI9SLHDNJokDI+Z9pA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.2",
     "react-router-dom": "^6.3.0",
-    "react-scripts": "5.0.1",
+    "react-scripts": "^5.0.1",
     "redux": "^4.2.0",
     "styled-components": "^5.3.5",
+    "validator": "^13.15.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/components/RegisterForm.js
+++ b/src/components/RegisterForm.js
@@ -196,7 +196,7 @@ return (
           width: 320,
           borderRadius: 3,
           alignSelf: 'left',
-          marginRight: 42,
+          marginRight: 41,
           marginBottom: 3
           
           }}
@@ -308,17 +308,7 @@ return (
                 onChange={(e) => {setConfirmPassword(e.target.value); handleChange(password,e.target.value);}}/>
                 
             </Box>
-            <Box marginTop={3} marginLeft={3} textAlign={'left'}>
-                <Typography sx={{color:(confirmPassword==password) ? 'green' : 'red'}} variant="body2">
-                    {getMessage('register.label.confirm.requirement')}
-                </Typography>
-                <Typography sx={{color:(confirmPassword==password) ? 'green' : 'red'}} fontSize={13}>
-                    {getMessage('register.label.confirm.requirement.two')}
-                </Typography>
-                <Typography sx={{color:(confirmPassword==password) ? 'green' : 'red'}} fontSize={13}>
-                    {getMessage('register.label.confirm.requirement.three')}
-                </Typography>
-            </Box>
+            
           </Box>
           
 

--- a/src/components/RegisterForm.js
+++ b/src/components/RegisterForm.js
@@ -1,9 +1,7 @@
 import {React, useState, sx} from 'react';
-import { Box, Typography, Button, TextField, InputLabel, Icon } from "@mui/material";
+import { Box, Typography, Button, TextField, InputLabel } from "@mui/material";
 import { getMessage } from "../services/MessageService";
-import { BorderAll } from '@mui/icons-material';
-import TaskAltIcon from '@mui/icons-material/TaskAlt';
-import CancelIcon from '@mui/icons-material/Cancel';
+
 
 
 function RegisterForm() {
@@ -19,6 +17,7 @@ const [userEmail, setUserEmail] = useState()
 const isEmail = () => /^[A-Z0-9._+-]+@[A-Z0-9-]+\.[A-Z]{2,4}$/i.test(userEmail);
 const [messageEmail, setMessageEmail] = useState("")
 const [messagePassword, setMessagePassword] = useState("")
+const [messageConfirm, setMessageConfirm] = useState("")
 
 const validaEmail = () => {
         
@@ -54,7 +53,6 @@ const validaEmail = () => {
   const [specialValidated, setSpecialValidated] = useState(false);
   const [lengthValidated, setLengthValidated] = useState(false);
   const [likeOthersValidated, setLikeOthersValidated] = useState(false);
-  const [confirmValidated, setConfirmValidated] = useState(false);
   const [confirmPassword, setConfirmPassword] = useState("");
   
 //"Mapeia" o que é digitado, através da função RegExp e o qua é determinado nela 
@@ -62,7 +60,7 @@ const validaEmail = () => {
   const lower = RegExp('(?=.*[a-z])');
   const upper = RegExp('(?=.*[A-Z])');
   const number = RegExp('(?=.*[0-9])');
-  const special = RegExp('(?=.*[!@#$%¨&*()\/<>:;~^|-])');
+  const special = RegExp('(?=.*[!@#$%¨&*()\/<>:;~?´`^|-])');
   const length = RegExp('.{8,}');
 
   //validando lowercase
@@ -111,9 +109,17 @@ if (
     setLikeOthersValidated(true);
   } 
 
-//confirmação de senha
-  setConfirmValidated(confirmPassword === password);
 };
+
+
+const validaConfirmacao = () => {
+  if (confirmPassword!==password){
+    setMessageConfirm(getMessage('register.label.password.confirm.error'));
+  }
+  else{
+    setMessageConfirm("");
+  }
+}
 
   //declaração das informações do formulário, para posteriormente enviar
   const [name, setName] = useState("")
@@ -130,54 +136,58 @@ return (
     >
 
       {/*Preenchimento de nome. Não é possível confirmar o formulário sem preenchê-lo */}
-        <Box>
-          {/*Label: Nome */}
-         <InputLabel htmlFor="name" sx={{
-            marginRight: 33}}>
-            {getMessage('register.label.name')}
-         </InputLabel>
-         {/*Campo de input - com a biblioteca MUI */}
-         <TextField
-          sx={{
-          width: 320,
-          borderRadius: 3,
-          alignSelf: 'center',
-          marginBottom: 3
-          }}
-            type="text"
-            placeholder="Digite seu nome"
-            onChange={(e) => setName(e.target.value)}
-          required
-          />
-        </Box>
+        <Box  alignSelf={'center'} display={"flex"} gap={1} flexDirection={"row"}>
+            <Box flexDirection={"row"}>
+            {/*Label: Nome */}
+          <InputLabel htmlFor="name" sx={{
+              marginRight: 33}}>
+              {getMessage('register.label.name')}
+          </InputLabel>
+          {/*Campo de input - com a biblioteca MUI */}
+          <TextField
+            sx={{
+            width: 320,
+            borderRadius: 3,
+            alignSelf: 'center',
+            marginBottom: 3
+            }}
+              type="text"
+              placeholder="Digite seu nome"
+              onChange={(e) => setName(e.target.value)}
+            required
+            />
+          </Box>
 
-         {/*Preenchimento de instituição. Não é possível confirmar o formulário sem preenchê-la */}
-        <Box>
-          {/*Label: Instituição */}
-         <InputLabel htmlFor="institution" sx={{
-            marginRight: 30}}>
-            {getMessage('register.label.institution')}
-         </InputLabel>
-         {/*Campo de input - com a biblioteca MUI */}
-         <TextField
-          sx={{
-          width: 320,
-          borderRadius: 3,
-          alignSelf: 'center',
-          marginBottom: 3
-          }}
-            type="text"
-            placeholder="Digite sua instituição"
-            onChange={(e) => setInstitution(e.target.value)}
-          required
-          />
+          {/*Preenchimento de instituição. Não é possível confirmar o formulário sem preenchê-la */}
+          <Box flexDirection={"row"}>
+              {/*Label: Instituição */}
+            <InputLabel htmlFor="institution" sx={{
+                marginRight: 30}}>
+                {getMessage('register.label.institution')}
+            </InputLabel>
+            {/*Campo de input - com a biblioteca MUI */}
+            <TextField
+              sx={{
+              width: 320,
+              borderRadius: 3,
+              alignSelf: 'center',
+              marginBottom: 3
+              }}
+                type="text"
+                placeholder="Digite sua instituição"
+                onChange={(e) => setInstitution(e.target.value)}
+              required
+              />
+          </Box>
+
         </Box>
+        
 
       {/*Preenchimento do email. Caso ele esteja vazio, aparecerá uma mensagem de erro. Também aparecerá se ele não estiver de acordo com um email (sem @ e .) */}
         <Box> 
           {/*Label: Email */}
         <InputLabel htmlFor = "userEmail" sx={{
-            marginRight: 33}}>
+            marginRight: 75}}>
             {getMessage('register.label.email')}
         </InputLabel>
         {/*Campo de input - com a biblioteca MUI */}
@@ -185,7 +195,9 @@ return (
           sx={{
           width: 320,
           borderRadius: 3,
-          alignSelf: 'center',
+          alignSelf: 'left',
+          marginRight: 42,
+          marginBottom: 3
           
           }}
             name = "email"
@@ -201,100 +213,83 @@ return (
         </Box>
 
         {/*Preenchimento de senha. Não é possível confirmar o formulário sem preenchê-la. Ela possui um sistema de validação */}
-        <Box>
-          {/*Label: Senha */}
-          <InputLabel sx={{
-            marginRight: 33}}>
-            {getMessage('register.label.password')}
-          </InputLabel>
-          {/*Campo de input - com a biblioteca MUI */}
-          <TextField
-          sx={{
-          width: 320,
-          borderRadius: 3,
-          alignSelf: 'center',
-          marginBottom: 3
-          }}
-            name = "password"
-            type={type}
-            placeholder="Digite sua senha"
-            onChange={(e) => [setPassword(e.target.value), handleChange(e.target.value) ]}
-            onBlur={validaSenha}
-            required
-            helperText = {messagePassword}
-            error = {messagePassword !== ""}
-            />
-            
+        <Box alignSelf={'center'} display={"flex"} gap={1} flexDirection={"row"}>
+          <Box flexDirection={'collumn'}>
+                <Box>
+                  {/*Label: Senha */}
+                  <InputLabel sx={{
+                    marginRight: 33}}>
+                    {getMessage('register.label.password')}
+                  </InputLabel>
+                  {/*Campo de input - com a biblioteca MUI */}
+                  <TextField
+                  sx={{
+                  width: 320,
+                  borderRadius: 3,
+                  alignSelf: 'left',
+                  marginBottom: 3
+                  }}
+                    name = "password"
+                    type={type}
+                    placeholder="Digite sua senha"
+                    onChange={(e) => [setPassword(e.target.value), handleChange(e.target.value) ]}
+                    onBlur={validaSenha}
+                    required
+                    helperText = {messagePassword}
+                    error = {messagePassword !== ""}
+                    />
+                    
+                </Box>
+
+                {/*Campo de verificação de senha */}
+
+                <Box width={200} marginLeft={3} marginBottom={4}  textAlign={'left'}>
+                  {/*Irá validar se a senha possui 8 ou mais caracteres */}
+                  <Typography variant='body2' sx={{color:lengthValidated ? 'green' : 'red'}}>
+                    {getMessage('register.validation.one')}
+                        
+                  </Typography>
+                  {/*Irá validar se a senha possui os requisitos pedidos */}
+          
+                    <Box>
+                      {/*Senha precisa de ao menos uma letra maiúscula */}
+                      <Typography sx={{color: upperValidated ? 'green' : 'red'}} fontSize={13}>
+                        {getMessage('register.validation.uppercase')}
+                          
+                      </Typography>
+                      {/*Senha precisa de ao menos uma letra minúscula */}
+                      <Typography sx={{color:lowerValidated ? 'green' : 'red'}} fontSize={13} >
+                        {getMessage('register.validation.lowercase')}
+                        
+                      </Typography>
+                      {/*Senha precisa de ao menos um número */}
+                      <Typography sx={{color:numberValidated ? 'green' : 'red'}} fontSize={13}>
+                        {getMessage('register.validation.number')}
+                        
+                      </Typography>
+                      {/*Senha precisa de ao menos um caracter especial */}
+                      <Typography sx={{color:specialValidated ? 'green' : 'red'}} fontSize={13} >
+                        {getMessage('register.validation.specialcarac')}
+                        
+                      </Typography>
+                      {/*Senha precisa ser diferente do nome ou email */}
+                      <Typography sx={{color:likeOthersValidated ? 'green' : 'red'}} fontSize={13} >
+                        {getMessage('register.validation.three')}
+                        
+                      </Typography>
+                  </Box>
+
+                </Box>
           </Box>
+          
           <Box>
 
-          {/*Campo de verificação de senha */}
-
-        <Box marginLeft={15} marginBottom={4}  textAlign={'justify'}>
-          {/*Irá validar se a senha possui 8 ou mais caracteres */}
-          <Typography variant='body2' sx={{color:lengthValidated ? 'green' : 'red'}}>
-            {getMessage('register.validation.one')}
-                  {lengthValidated ? (
-                    <TaskAltIcon fontSize="x-small" />
-                  ) : (
-                    <CancelIcon fontSize="x-x-small" />
-                  )}
-          </Typography>
-          {/*Irá validar se a senha possui 3 dos 4 requisitos pedidos */}
-          <Typography variant='body2'>
-            {getMessage('register.validation.two')}
-            <Box>
-              {/*Senha precisa de ao menos uma letra maiúscula */}
-              <Typography sx={{color: upperValidated ? 'green' : 'red'}} fontSize={13}>
-                {getMessage('register.validation.uppercase')}
-                  {upperValidated ? (
-                    <TaskAltIcon fontSize="x-small" />
-                  ) : (
-                    <CancelIcon fontSize="x-small" />
-                  )}
-              </Typography>
-              {/*Senha precisa de ao menos uma letra minúscula */}
-              <Typography sx={{color:lowerValidated ? 'green' : 'red'}} fontSize={13} >
-                {getMessage('register.validation.lowercase')}
-                {lowerValidated ? (
-                    <TaskAltIcon fontSize="x-small" />
-                  ) : (
-                    <CancelIcon fontSize="x-small" />
-                  )}
-              </Typography>
-              {/*Senha precisa de ao menos um número */}
-              <Typography sx={{color:numberValidated ? 'green' : 'red'}} fontSize={13}>
-                {getMessage('register.validation.number')}
-                {numberValidated ? (
-                    <TaskAltIcon fontSize="x-small" />
-                  ) : (
-                    <CancelIcon fontSize="x-small" />
-                  )}
-              </Typography>
-              {/*Senha precisa de ao menos um caracter especial */}
-              <Typography sx={{color:specialValidated ? 'green' : 'red'}} fontSize={13} >
-                {getMessage('register.validation.specialcarac')}
-                {specialValidated ? (
-                    <TaskAltIcon fontSize="x-small" />
-                  ) : (
-                    <CancelIcon fontSize="x-small" />
-                  )}
-              </Typography>
-              {/*Senha precisa ser diferente do nome ou email */}
-              <Typography sx={{color:likeOthersValidated ? 'green' : 'red'}} fontSize={13} >
-                {getMessage('register.validation.three')}
-                {likeOthersValidated ? (
-                    <TaskAltIcon fontSize="x-small" />
-                  ) : (
-                    <CancelIcon fontSize="x-small" />
-                  )}
-              </Typography>
- 
-          </Box>
+       
             {/*Confirmação de senha */}
-          <Box>
+          <Box flexDirection={"row"}>
+            <Box>
             <InputLabel sx={{
-              marginRight: 30, marginTop: 3}}>
+              marginRight: 21}}>
               {getMessage('register.label.password.confirm')}
             </InputLabel>
             {/*Input */}
@@ -303,30 +298,41 @@ return (
               width: 320,
               borderRadius: 3,
               alignSelf: 'center',
-              marginBottom: 3
               }}
+                onblur={validaConfirmacao}
                 type="password"
                 value={confirmPassword}
                 placeholder="Confirme sua senha"
+                error = {confirmPassword !== password}
+                helperText = {messageConfirm}
                 onChange={(e) => {setConfirmPassword(e.target.value); handleChange(password,e.target.value);}}/>
-                {confirmValidated ? (
-                  <TaskAltIcon color='green' fontSize="x-small" />
-                ) : (
-                  <CancelIcon color='red' fontSize="x-small" />
-                )}
-
+                
+            </Box>
+            <Box marginTop={3} marginLeft={3} textAlign={'left'}>
+                <Typography sx={{color:(confirmPassword==password) ? 'green' : 'red'}} variant="body2">
+                    {getMessage('register.label.confirm.requirement')}
+                </Typography>
+                <Typography sx={{color:(confirmPassword==password) ? 'green' : 'red'}} fontSize={13}>
+                    {getMessage('register.label.confirm.requirement.two')}
+                </Typography>
+                <Typography sx={{color:(confirmPassword==password) ? 'green' : 'red'}} fontSize={13}>
+                    {getMessage('register.label.confirm.requirement.three')}
+                </Typography>
+            </Box>
           </Box>
-          </Typography>
           
 
+        
+          
         </Box>
           
         </Box>
+
         <Button
         disabled={
             !(
-              (lowerValidated || upperValidated) && (numberValidated || specialValidated) && (lowerValidated || numberValidated)
-               && lengthValidated && likeOthersValidated && confirmValidated
+              lowerValidated && upperValidated && numberValidated && specialValidated && lowerValidated && numberValidated
+               && lengthValidated && likeOthersValidated  && (confirmPassword === password)
             )
           } 
           sx={{width: 310, 

--- a/src/components/RegisterForm.js
+++ b/src/components/RegisterForm.js
@@ -1,0 +1,352 @@
+import {React, useState, sx} from 'react';
+import { Box, Typography, Button, TextField, InputLabel, Icon } from "@mui/material";
+import { getMessage } from "../services/MessageService";
+import { BorderAll } from '@mui/icons-material';
+import TaskAltIcon from '@mui/icons-material/TaskAlt';
+import CancelIcon from '@mui/icons-material/Cancel';
+
+
+function RegisterForm() {
+  //Envio das informações do formulário
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    console.log( name, institution, userEmail, password );
+  }
+
+// Código de validação de e-mail (linhas 16-40)
+
+const [userEmail, setUserEmail] = useState()
+const isEmail = () => /^[A-Z0-9._+-]+@[A-Z0-9-]+\.[A-Z]{2,4}$/i.test(userEmail);
+const [messageEmail, setMessageEmail] = useState("")
+const [messagePassword, setMessagePassword] = useState("")
+
+const validaEmail = () => {
+        
+        //Verifica se o e-mail existe 
+        if(userEmail === "") {
+            setMessageEmail(getMessage('register.label.email.empty.message'));
+          } else{
+            setMessageEmail("");
+          }
+
+          //Verifica o formato do e=mail
+        if(isEmail(userEmail) && !/[._+-]/.test(userEmail[0])) {
+                setMessageEmail("");
+        } 
+        else {
+            setMessageEmail(getMessage('register.label.email.error.message'));
+         }
+   
+    }
+
+  //Código de validação de senha (linhas 42-112)
+  const validaSenha = () => {
+    if(password === "") {
+            setMessagePassword(getMessage('register.label.password.error'));
+        } else{
+            setMessagePassword("");}
+  }
+  const [type, setType] = useState("password")
+
+  const [lowerValidated, setLowerValidated] = useState(false);
+  const [upperValidated, setUpperValidated] = useState(false);
+  const [numberValidated, setNumberValidated] = useState(false);
+  const [specialValidated, setSpecialValidated] = useState(false);
+  const [lengthValidated, setLengthValidated] = useState(false);
+  const [likeOthersValidated, setLikeOthersValidated] = useState(false);
+  const [confirmValidated, setConfirmValidated] = useState(false);
+  const [confirmPassword, setConfirmPassword] = useState("");
+  
+//"Mapeia" o que é digitado, através da função RegExp e o qua é determinado nela 
+  const handleChange=(password, confirmPassword) => {
+  const lower = RegExp('(?=.*[a-z])');
+  const upper = RegExp('(?=.*[A-Z])');
+  const number = RegExp('(?=.*[0-9])');
+  const special = RegExp('(?=.*[!@#$%¨&*()\/<>:;~^|-])');
+  const length = RegExp('.{8,}');
+
+  //validando lowercase
+  if(lower.test(password)){
+    setLowerValidated(true);
+  }
+  else{
+    setLowerValidated(false);
+  }
+  //validando uppercase
+    if(upper.test(password)){
+    setUpperValidated(true);
+  }
+  else{
+    setUpperValidated(false);
+  }
+  // validando número
+   if(number.test(password)){
+    setNumberValidated(true);
+  }
+  else{
+    setNumberValidated(false);
+  }
+  // validando caractere especial
+    if(special.test(password)){
+    setSpecialValidated(true);
+  }
+  else{
+    setSpecialValidated(false);
+  }
+  //validando tamanho da senha
+   if(length.test(password)){
+    setLengthValidated(true);
+  }
+  else{
+    setLengthValidated(false);
+  }
+
+//checando se a senha é igual ao nome ou ao e-mail
+if (
+    password.toLowerCase() === name?.toLowerCase() ||
+    password.toLowerCase() === email?.toLowerCase()
+  ) {
+    setLikeOthersValidated(false);
+  } else {
+    setLikeOthersValidated(true);
+  } 
+
+//confirmação de senha
+  setConfirmValidated(confirmPassword === password);
+};
+
+  //declaração das informações do formulário, para posteriormente enviar
+  const [name, setName] = useState("")
+  const [institution, setInstitution] = useState("")
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+return (
+    //Caixa que envolve todos os campos de formulário
+    <Box
+      component="form"
+      autoComplete='off'
+      onSubmit ={handleSubmit}
+      sx={{ display: "flex", flexDirection: "column", gap: 2 }}
+    >
+
+      {/*Preenchimento de nome. Não é possível confirmar o formulário sem preenchê-lo */}
+        <Box>
+          {/*Label: Nome */}
+         <InputLabel htmlFor="name" sx={{
+            marginRight: 33}}>
+            {getMessage('register.label.name')}
+         </InputLabel>
+         {/*Campo de input - com a biblioteca MUI */}
+         <TextField
+          sx={{
+          width: 320,
+          borderRadius: 3,
+          alignSelf: 'center',
+          marginBottom: 3
+          }}
+            type="text"
+            placeholder="Digite seu nome"
+            onChange={(e) => setName(e.target.value)}
+          required
+          />
+        </Box>
+
+         {/*Preenchimento de instituição. Não é possível confirmar o formulário sem preenchê-la */}
+        <Box>
+          {/*Label: Instituição */}
+         <InputLabel htmlFor="institution" sx={{
+            marginRight: 30}}>
+            {getMessage('register.label.institution')}
+         </InputLabel>
+         {/*Campo de input - com a biblioteca MUI */}
+         <TextField
+          sx={{
+          width: 320,
+          borderRadius: 3,
+          alignSelf: 'center',
+          marginBottom: 3
+          }}
+            type="text"
+            placeholder="Digite sua instituição"
+            onChange={(e) => setInstitution(e.target.value)}
+          required
+          />
+        </Box>
+
+      {/*Preenchimento do email. Caso ele esteja vazio, aparecerá uma mensagem de erro. Também aparecerá se ele não estiver de acordo com um email (sem @ e .) */}
+        <Box> 
+          {/*Label: Email */}
+        <InputLabel htmlFor = "userEmail" sx={{
+            marginRight: 33}}>
+            {getMessage('register.label.email')}
+        </InputLabel>
+        {/*Campo de input - com a biblioteca MUI */}
+          <TextField
+          sx={{
+          width: 320,
+          borderRadius: 3,
+          alignSelf: 'center',
+          
+          }}
+            name = "email"
+            type="text"
+            placeholder="nome@email.com"
+            onChange={(e) => setUserEmail(e.target.value)}
+            onBlur={validaEmail}
+            required
+            helperText = {messageEmail}
+            error = {messageEmail !== ""}
+          />
+          
+        </Box>
+
+        {/*Preenchimento de senha. Não é possível confirmar o formulário sem preenchê-la. Ela possui um sistema de validação */}
+        <Box>
+          {/*Label: Senha */}
+          <InputLabel sx={{
+            marginRight: 33}}>
+            {getMessage('register.label.password')}
+          </InputLabel>
+          {/*Campo de input - com a biblioteca MUI */}
+          <TextField
+          sx={{
+          width: 320,
+          borderRadius: 3,
+          alignSelf: 'center',
+          marginBottom: 3
+          }}
+            name = "password"
+            type={type}
+            placeholder="Digite sua senha"
+            onChange={(e) => [setPassword(e.target.value), handleChange(e.target.value) ]}
+            onBlur={validaSenha}
+            required
+            helperText = {messagePassword}
+            error = {messagePassword !== ""}
+            />
+            
+          </Box>
+          <Box>
+
+          {/*Campo de verificação de senha */}
+
+        <Box marginLeft={15} marginBottom={4}  textAlign={'justify'}>
+          {/*Irá validar se a senha possui 8 ou mais caracteres */}
+          <Typography variant='body2' sx={{color:lengthValidated ? 'green' : 'red'}}>
+            {getMessage('register.validation.one')}
+                  {lengthValidated ? (
+                    <TaskAltIcon fontSize="x-small" />
+                  ) : (
+                    <CancelIcon fontSize="x-x-small" />
+                  )}
+          </Typography>
+          {/*Irá validar se a senha possui 3 dos 4 requisitos pedidos */}
+          <Typography variant='body2'>
+            {getMessage('register.validation.two')}
+            <Box>
+              {/*Senha precisa de ao menos uma letra maiúscula */}
+              <Typography sx={{color: upperValidated ? 'green' : 'red'}} fontSize={13}>
+                {getMessage('register.validation.uppercase')}
+                  {upperValidated ? (
+                    <TaskAltIcon fontSize="x-small" />
+                  ) : (
+                    <CancelIcon fontSize="x-small" />
+                  )}
+              </Typography>
+              {/*Senha precisa de ao menos uma letra minúscula */}
+              <Typography sx={{color:lowerValidated ? 'green' : 'red'}} fontSize={13} >
+                {getMessage('register.validation.lowercase')}
+                {lowerValidated ? (
+                    <TaskAltIcon fontSize="x-small" />
+                  ) : (
+                    <CancelIcon fontSize="x-small" />
+                  )}
+              </Typography>
+              {/*Senha precisa de ao menos um número */}
+              <Typography sx={{color:numberValidated ? 'green' : 'red'}} fontSize={13}>
+                {getMessage('register.validation.number')}
+                {numberValidated ? (
+                    <TaskAltIcon fontSize="x-small" />
+                  ) : (
+                    <CancelIcon fontSize="x-small" />
+                  )}
+              </Typography>
+              {/*Senha precisa de ao menos um caracter especial */}
+              <Typography sx={{color:specialValidated ? 'green' : 'red'}} fontSize={13} >
+                {getMessage('register.validation.specialcarac')}
+                {specialValidated ? (
+                    <TaskAltIcon fontSize="x-small" />
+                  ) : (
+                    <CancelIcon fontSize="x-small" />
+                  )}
+              </Typography>
+              {/*Senha precisa ser diferente do nome ou email */}
+              <Typography sx={{color:likeOthersValidated ? 'green' : 'red'}} fontSize={13} >
+                {getMessage('register.validation.three')}
+                {likeOthersValidated ? (
+                    <TaskAltIcon fontSize="x-small" />
+                  ) : (
+                    <CancelIcon fontSize="x-small" />
+                  )}
+              </Typography>
+ 
+          </Box>
+            {/*Confirmação de senha */}
+          <Box>
+            <InputLabel sx={{
+              marginRight: 30, marginTop: 3}}>
+              {getMessage('register.label.password.confirm')}
+            </InputLabel>
+            {/*Input */}
+            <TextField
+              sx={{
+              width: 320,
+              borderRadius: 3,
+              alignSelf: 'center',
+              marginBottom: 3
+              }}
+                type="password"
+                value={confirmPassword}
+                placeholder="Confirme sua senha"
+                onChange={(e) => {setConfirmPassword(e.target.value); handleChange(password,e.target.value);}}/>
+                {confirmValidated ? (
+                  <TaskAltIcon color='green' fontSize="x-small" />
+                ) : (
+                  <CancelIcon color='red' fontSize="x-small" />
+                )}
+
+          </Box>
+          </Typography>
+          
+
+        </Box>
+          
+        </Box>
+        <Button
+        disabled={
+            !(
+              (lowerValidated || upperValidated) && (numberValidated || specialValidated) && (lowerValidated || numberValidated)
+               && lengthValidated && likeOthersValidated && confirmValidated
+            )
+          } 
+          sx={{width: 310, 
+          height: 40, 
+          alignSelf: 'center', 
+          borderRadius: 2, 
+          marginBottom: 5,
+          bgcolor: 'primary.main',
+              '&:hover': {
+                bgcolor: 'primary.light',
+              }}} 
+          variant = "contained"
+          type = "submit" >
+          {getMessage('register.button')}
+      </Button>
+ </Box>
+ 
+)
+}
+
+
+
+export default RegisterForm;

--- a/src/pages/Register.js
+++ b/src/pages/Register.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import Logo from '../static/images/logo.png';
 import {Stack} from "@mui/system";
 import { Box, Paper, Typography } from "@mui/material";
 import { getMessage } from "../services/MessageService";
@@ -10,13 +9,10 @@ const Register = () => {
     <Stack>
         <Box 
         sx={{ display: 'flex',
-              width: 550,
-              height: 1030,
+              width: 900,
+              height: 750,
               borderRadius: 3,
               bgcolor: '#fff',
-              '&:hover': {
-                bgcolor: '#EBFAF4',
-              },
               marginTop: 10,
               marginBottom: 10,
               paddingTop: 10,
@@ -29,10 +25,6 @@ const Register = () => {
                {getMessage('register.title')} 
             </Typography>
             <RegisterForm />
-            <Box sx={{alignSelf:'center'}}>
-               <img height={50} width={50} src={Logo} alt="Logo olATCG" /> 
-           </Box>
-            
         </Box>
         
     </Stack>

--- a/src/pages/Register.js
+++ b/src/pages/Register.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import Logo from '../static/images/logo.png';
+import {Stack} from "@mui/system";
+import { Box, Paper, Typography } from "@mui/material";
+import { getMessage } from "../services/MessageService";
+import RegisterForm from '../components/RegisterForm';
+
+const Register = () => {
+    return <>
+    <Stack>
+        <Box 
+        sx={{ display: 'flex',
+              width: 550,
+              height: 1030,
+              borderRadius: 3,
+              bgcolor: '#fff',
+              '&:hover': {
+                bgcolor: '#EBFAF4',
+              },
+              marginTop: 10,
+              marginBottom: 10,
+              paddingTop: 10,
+              alignSelf: 'center',
+              textAlign:'center',
+              boxShadow: 3,
+              flexDirection: 'column'
+            }}>
+            <Typography variant='h4' color="#1A7A69" marginBottom={5}>
+               {getMessage('register.title')} 
+            </Typography>
+            <RegisterForm />
+            <Box sx={{alignSelf:'center'}}>
+               <img height={50} width={50} src={Logo} alt="Logo olATCG" /> 
+           </Box>
+            
+        </Box>
+        
+    </Stack>
+    
+    </>
+}
+export default Register;

--- a/src/routes/AppRoutes.js
+++ b/src/routes/AppRoutes.js
@@ -5,12 +5,14 @@ import Learn from '../pages/Learn';
 import Tools from '../pages/Tools';
 import Tutorials from '../pages/Tutorials';
 import Homology from '../pages/Homology';
+
 import { Analysis } from '../pages/Analysis';
 import { HomologyAnalysis } from '../pages/HomologyAnalysis';
 import { AlignmentAnalysis } from '../pages/AlignmentAnalysis';
 import { PhylogeneticTreeAnalysis } from '../pages/PhylogeneticTreeAnalysis';
 import { AlignmentAnalysisDetails } from '../pages/AlignmentAnalysisDetails';
 import { HomologyAnalysisDetails } from '../pages/HomologyAnalysisDetails';
+import Register from '../pages/Register';
 import PhyloTree from '../pages/PhyloTree';
 
 export default function AppRoutes(){
@@ -18,8 +20,10 @@ export default function AppRoutes(){
         <Routes>
             <Route path="home" element={<Home />} />
             <Route path="learn" element={<Learn />} />
-            <Route path="tutorials" element={<Tutorials />} />
+            <Route path="tutorials" element={<Tutorials />} /> 
+            <Route path="register" element={<Register />}/>
             <Route path="tool" element={<Tools />}>
+           
                 <Route path="alignment" element={<Alignment />} />
                 <Route path="homology" element={<Homology />} />
             </Route>

--- a/src/routes/AppRoutes.js
+++ b/src/routes/AppRoutes.js
@@ -21,7 +21,7 @@ export default function AppRoutes(){
             <Route path="home" element={<Home />} />
             <Route path="learn" element={<Learn />} />
             <Route path="tutorials" element={<Tutorials />} /> 
-            <Route path="register" element={<Register />}/>
+            <Route path="register" element={<Register />} />
             <Route path="tool" element={<Tools />}>
            
                 <Route path="alignment" element={<Alignment />} />

--- a/src/services/MessageService.js
+++ b/src/services/MessageService.js
@@ -276,6 +276,25 @@ var data_en = {
 
     'info.analysis.isnt.finished'            : 'The proccess still running. Try again when the status of this ' +
                                                     'analysis changes to \'FINSHED\'',
+    //REGISTER
+                
+    'register.title'                         : 'Sign up to OLATCG',
+    'register.button'                        : 'Sign up',
+    'register.label.name'                    : 'Name:',
+    'register.label.institution'             : 'Institution:',
+    'register.label.email'                   : 'E-mail:',
+    'register.label.email.empty.message'     : 'The email is empty. Try again',
+    'register.label.email.error.message'     : 'Enter with a valid e-mail',
+    'register.label.password'                : 'Password:',
+    'register.label.password.confirmation'   : 'Confirm your password:',
+    'register.label.password.error'          : 'Your password is empty. Try again.',
+    'register.validation.one'                : 'Minimum of 8 characters',
+    'register.validation.two'                : 'At least 3 of the 4 requirements',
+    'register.validation.uppercase'          : '- At least one uppercase letter',
+    'register.validation.lowercase'          : '- At least one lowercase letter',
+    'register.validation.number'             : '- At least one number',
+    'register.validation.specialcarac'       : '- At least one special character',
+    'register.validation.three'              : 'Diferent from the name or email.',
 
     // ERRORS
 
@@ -574,6 +593,27 @@ var data = {
 
     'info.analysis.isnt.finished'            : 'O processo está em andamento. Tente de novo quando o status ' + 
                                                     'para está análise for \'FINSHED\'',
+    
+    //REGISTER
+
+    'register.title'                         : 'Cadastre-se no OLATCG',
+    'register.button'                        : 'Cadastrar',
+    'register.label.name'                    : 'Nome:',
+    'register.label.institution'             : 'Instituição:',
+    'register.label.email'                   : 'E-mail:',
+    'register.label.email.empty.message'     : 'O e-mail está vazio. Entre novamente',
+    'register.label.email.error.message'     : 'Entre com um e-mail válido',
+    'register.label.password'                : 'Senha:',
+    'register.label.password.confirm'        : 'Confirme sua senha:',
+    'register.label.password.error'          : 'A senha está vazia. Entre novamente.',
+    'register.validation.one'                : 'Mínimo de 8 caracteres',
+    'register.validation.two'                : 'Ao menos 3 de 4 recursos:',
+    'register.validation.uppercase'          : '- Ao menos uma letra maiúscula',
+    'register.validation.lowercase'          : '- Ao menos uma letra minúscula',
+    'register.validation.number'             : '- Ao menos um número',
+    'register.validation.specialcarac'       : '- Ao menos um caractere especial',
+    'register.validation.three'              : 'Diferente do nome ou e-mail',
+
 
     // ERRORS
 

--- a/src/services/MessageService.js
+++ b/src/services/MessageService.js
@@ -308,7 +308,6 @@ var data_en = {
                                                     'if they match the choosen type and try again',
     'error.validation.sequenceFile.type'        : 'The sequence file must be of type .txt',
 };
-
 var data = {
 
     /* COMMON */
@@ -605,13 +604,15 @@ var data = {
     'register.label.email.error.message'     : 'Entre com um e-mail válido',
     'register.label.password'                : 'Senha:',
     'register.label.password.confirm'        : 'Confirme sua senha:',
+    'register.label.confirm.requirement'     : 'A confirmação de senha confere',
+    'register.label.confirm.requirement.two' : '- É preciso ter os mesmos caracteres',
+    'register.label.confirm.requirement.three' : '- Cheque a senha para confirmar o cadastro',
     'register.label.password.error'          : 'A senha está vazia. Entre novamente.',
     'register.validation.one'                : 'Mínimo de 8 caracteres',
-    'register.validation.two'                : 'Ao menos 3 de 4 recursos:',
     'register.validation.uppercase'          : '- Ao menos uma letra maiúscula',
     'register.validation.lowercase'          : '- Ao menos uma letra minúscula',
     'register.validation.number'             : '- Ao menos um número',
-    'register.validation.specialcarac'       : '- Ao menos um caractere especial',
+    'register.validation.specialcarac'       : '- Ao menos um caractere especial (Ex:!@#$%¨&*():~?´`^)',
     'register.validation.three'              : 'Diferente do nome ou e-mail',
 
 


### PR DESCRIPTION
### Context
----------
Currently, at OLATCG, we do not store any user information. This makes it impossible for us to know who carried out the analyses and means that **all users** have access to **all analyses** carried out in the system.

We need to deal with this scenario so that each user can only view their own analyses and experiments.

### About the code
---

- In order to solve the problem above, a prototype of a user registration page was created, using React's Material UI library.

- The user needs to register via the input fields, which ask for their name, their institution, their e-mail address, a password for their account and a confirmation of it.

- The email field is validated with the on blur function, checking the standard format of an email and whether it is empty or not. In the event of an error, a message appears below the field.

- The password is validated according to the criteria, which appear below its input field. To do this, it was used JavaScript's RegExp object, which checks a sequence of characters. In addition, conditionals have also been implemented which influence the appearance of the necessary requirements, turning green if they are met and remaining red if they are incorrect.
- In order to prevent the user from submiting te form with an invalid e-mail or password, the submit button is disabled if the e-mail isn't valid or the password doesn't meet the requirements.
- When the user completes the form and confirms their registration, it is possible to view their information in the console (considering that this page is not yet integrated with the backend, it is the only way for now that it's possible to see the data).
- This page is also integrated with the AppRoutes of olatcg-fronted, making it possible to see the page through the path 'localhost:3000/olatcg/register'.
