### PR TITLE
Creation of an experiment

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.2",
     "react-router-dom": "^6.3.0",
-    "react-scripts": "5.0.1",
+    "react-scripts": "^5.0.1",
     "redux": "^4.2.0",
     "styled-components": "^5.3.5",
+    "validator": "^13.15.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {
@@ -48,5 +49,7 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "proxy": "https://spica.eic.cefet-rj.br"
+
 }

--- a/src/components/ExperimentForm.js
+++ b/src/components/ExperimentForm.js
@@ -1,0 +1,137 @@
+import {React, useState, sx} from 'react';
+import { Box, Typography, Button, TextField, InputLabel, InputAdornment, Alert} from "@mui/material";
+import {API_ROUTES} from '../routes/Routes';
+import { getMessage } from "../services/MessageService";
+
+const ExperimentForm = () => {
+
+    let url = "http://localhost:8000/v3/olatcg-backend/experiment/" ;
+    const maxDescriptionLength = 100
+    const maxTitleLength = 20
+
+    const [experimentTitle, setExperimentTitle] = useState('');
+    const [experimentDescription, setExperimentDescription] = useState('');
+    const [successMessage, setSuccessMessage] = useState(null);
+    const [errorMessage, setErrorMessage] = useState(null);
+    
+    const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSuccessMessage(null);
+    setErrorMessage(null);
+    {/*Autorização com o token */}
+  
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": "Token 983b98f522c9faad02555820fe24108e0b101985",
+        },
+        body: JSON.stringify({
+          title: experimentTitle,
+          description: experimentDescription,
+        }),
+      });
+
+      {/*Mensagens de sucesso ou erro */}
+      if (response.ok) {
+        setSuccessMessage(getMessage('experiment.success.message'));
+      } else {
+        const errorData = await response.json();
+        setErrorMessage(
+          `Erro ao criar experimento: ${errorData.message || response.statusText}`
+        );
+      }
+    } catch (error) {
+      setErrorMessage(getMessage('experiment.error.message'));
+    }
+  };
+   {/*Formulário de criação de experimento */}
+    return <>
+    <form onSubmit={handleSubmit}>
+    {/*Título do experimento */}
+        <Box
+    sx={{
+        justifyContent: "center",
+        flexDirection: "column",
+        marginBottom: 4,
+        textAlign: 'center'
+    }}>
+        <Typography>{getMessage('experiment.title')}</Typography>
+        <TextField
+        sx={{width: 500}}  
+        placeholder='Digite o título do experimento'
+        value={experimentTitle}
+        InputProps={{
+                     endAdornment:(<InputAdornment position='end'>
+                        {maxTitleLength - experimentTitle.length}
+                        </InputAdornment>)}}
+        required
+        focused
+        onChange={(event) => setExperimentTitle(event.target.value)}>
+        </TextField>
+    </Box>
+    {/*Descrição do experimento */}
+    <Box
+    sx={{
+        justifyContent: "center",
+        flexDirection: "column",
+        textAlign: "center"}}>
+        <Typography>{getMessage('experiment.description')}</Typography>
+        <TextField 
+        sx={{width: 500
+        }} 
+        placeholder='Digite a descrição do experimento'
+        value={experimentDescription}
+        rows={5}
+        InputProps={{
+                     endAdornment:(<InputAdornment position='end'
+                       sx={{marginTop: 'auto'}}>
+                        {maxDescriptionLength - experimentDescription.length}
+                        </InputAdornment>)}}
+        multiline
+        required
+        focused
+        onChange={(event) => setExperimentDescription(event.target.value)}>
+
+        </TextField>
+        
+    </Box>
+     {/*  Mensagem de sucesso (aparição na tela)*/}
+      {successMessage && (
+        <Box marginTop={1}>
+          <Alert  variant="outlined" severity="success">{successMessage}</Alert>
+        </Box>
+      )}
+
+      {/* Mensagem de erro (aparição na tela)*/}
+      {errorMessage && (
+        <Box marginTop={1}>
+          <Alert variant="outlined" severity="error">{errorMessage}</Alert>
+        </Box>
+      )}
+
+    <Box display={'flex'} justifyContent={'center'}>
+        <Button
+         sx={{width: 150, 
+                  height: 45, 
+                  borderRadius: 1, 
+                  marginTop: 3,
+                  bgcolor: 'primary.main',
+                      '&:hover': {
+                        bgcolor: 'primary.light', 
+                      },}}
+                   
+                  variant = "contained"
+                  type = "submit" >
+            {getMessage('experiment.button')}
+        </Button>
+    </Box>
+    
+    </form>
+    
+    </>
+    
+}
+
+export default ExperimentForm;

--- a/src/pages/Experiment.js
+++ b/src/pages/Experiment.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import {Stack} from "@mui/system";
+import { Box, Paper, Typography } from "@mui/material";
+import { getMessage } from "../services/MessageService";
+import ExperimentForm from "../components/ExperimentForm";
+import { API_ROUTES } from '../routes/Routes';
+
+const Experiment = () => {
+    return <>
+    <Stack>
+        <Box
+        sx={{display: "flex",
+            width: 1200,
+            height: 450,
+            alignSelf: "center",
+            justifyContent: "center",
+            backgroundColor: "white",
+            marginTop: 10,
+            boxShadow: 1
+        }}> 
+            <Box 
+            sx={{flexDirection: "column",
+                alignSelf: "center",
+                justifyContent: "center",
+                alignItems: "center"
+            }}
+            > 
+                <ExperimentForm />
+            </Box>
+               
+        </Box>
+
+    </Stack>
+
+    </>
+  
+}
+ export default Experiment;

--- a/src/routes/AppRoutes.js
+++ b/src/routes/AppRoutes.js
@@ -5,6 +5,8 @@ import Learn from '../pages/Learn';
 import Tools from '../pages/Tools';
 import Tutorials from '../pages/Tutorials';
 import Homology from '../pages/Homology';
+import Register from '../pages/Register';
+import Experiment from '../pages/Experiment';
 import { Analysis } from '../pages/Analysis';
 import { HomologyAnalysis } from '../pages/HomologyAnalysis';
 import { AlignmentAnalysis } from '../pages/AlignmentAnalysis';
@@ -18,11 +20,14 @@ export default function AppRoutes(){
         <Routes>
             <Route path="home" element={<Home />} />
             <Route path="learn" element={<Learn />} />
-            <Route path="tutorials" element={<Tutorials />} />
+            <Route path="tutorials" element={<Tutorials />} /> 
+            <Route path="register" element={<Register />} />
             <Route path="tool" element={<Tools />}>
+           
                 <Route path="alignment" element={<Alignment />} />
                 <Route path="homology" element={<Homology />} />
             </Route>
+            <Route path="experiment" element={<Experiment />} />
             <Route path="analysis" element={<Analysis />}>
                 <Route path="alignment" element={<AlignmentAnalysis />}>
                     <Route path=":idAnalysis" element={<AlignmentAnalysisDetails/>} />

--- a/src/routes/Routes.js
+++ b/src/routes/Routes.js
@@ -1,7 +1,7 @@
-var BASE_URL = process.env.REACT_APP_BACKEND_URL || 'https://spica.eic.cefet-rj.br';
+var BASE_URL = process.env.REACT_APP_BACKEND_URL || 'http://localhost:8000';
 
 //var API_BASE_PATH = BASE_URL + '/v1/api';
-var API_BASE_PATH = BASE_URL + '/v2/olatcg-backend';
+var API_BASE_PATH = BASE_URL + '/v3/olatcg-backend'; 
 
 //BACKEND ROUTES
 const API_ROUTES = {

--- a/src/services/MessageService.js
+++ b/src/services/MessageService.js
@@ -277,6 +277,15 @@ var data_en = {
     'info.analysis.isnt.finished'            : 'The proccess still running. Try again when the status of this ' +
                                                     'analysis changes to \'FINSHED\'',
 
+    //EXPERIMENT
+
+    'experiment.title'                       : 'Insert the title of your experiment',
+    'experiment.description'                 : 'Insert the description of your experiment',
+    'experiment.error'                       : 'Invalid field!',
+    'experiment.button'                      : 'Create experiment',
+    'experiment.success.message'             : 'Experiment created successfully',
+    'experiment.error.message'               : 'Network error or server down.',
+
     // ERRORS
 
     'error.general'                             : 'An error occurred while trying to establish the connection. ' +
@@ -574,6 +583,14 @@ var data = {
 
     'info.analysis.isnt.finished'            : 'O processo está em andamento. Tente de novo quando o status ' + 
                                                     'para está análise for \'FINSHED\'',
+    
+    //EXPERIMENT
+    'experiment.title'                       : 'Insira o título do seu experimento',
+    'experiment.description'                 : 'Insira a descrição do seu experimento',
+    'experiment.error'                       : 'Campo inválido!',
+    'experiment.button'                      : 'Criar experimento',
+    'experiment.success.message'             : 'Experimento criado com sucesso!',
+    'experiment.error.message'               : 'Erro de rede ou servidor fora do ar.',
 
     // ERRORS
 


### PR DESCRIPTION
Currently, all the analyses are linked to a single experiment, making it impossible to group them together.

The user needs to be able to create experiments. Each experiment must contain the following information:

Title
Description
When filled in and a successful response is obtained from the server, a banner should be displayed with a success message indicating that the operation has been completed successfully.

If there is an error, this message should be displayed to the client and, if necessary, dealt with.

Acceptance criteria

A new experiment is created in the database

A success message is displayed if the operation is successful

A failure message is displayed in the event of an error containing the error returned by the API

