### PR TITLE
69 update analysis pages with filter fields for analysis search

### DIFF
--- a/src/pages/AlignmentAnalysis.js
+++ b/src/pages/AlignmentAnalysis.js
@@ -1,4 +1,4 @@
-import { Box, Button, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Pagination } from "@mui/material";
+import { Box, Button, Checkbox, FilledInput, FormControl, InputLabel, ListItemText, MenuItem, Paper, Select, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TextField, Typography, Pagination } from "@mui/material";
 import { useEffect, useState } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import OlatcgSnackbar from "../components/OlatcgSnackbar";
@@ -22,7 +22,55 @@ const AlignmentAnalysis = () => {
     const [info, setInfo] = useState(false);
     const [selectedPage, setSelectedPage] = useState(0);
     const [totalPages, setTotalPages] = useState();
-    
+
+    const [searchFormData, setSearchFormData] = useState({
+        textFieldTitle: "",
+        selectFieldType: [
+            'PAIRWISE_ALIGNMENT',
+            'HOMOLOGY_SEARCH',
+            'TAXONOMY_TREE',
+        ],
+        selectFieldStatus: [
+            'SUCCEEDED',
+            'STARTED',
+            'WAITING',
+            'ERROR',
+        ],
+    })
+
+    const analysisType = [
+        {
+            label: getMessage('analysisField.label.type.alignment'),
+            value: 'PAIRWISE_ALIGNMENT',
+        },
+        {
+            label: getMessage('analysisField.label.type.homology'),
+            value: 'HOMOLOGY_SEARCH',
+        },
+        {
+            label: getMessage('analysisField.label.type.phyloTree'),
+            value: 'TAXONOMY_TREE',
+        },
+    ]
+
+    const analysisStatus = [
+        { 
+            label: getMessage('analysisField.label.status.success'),
+            value:'SUCCEEDED',
+        },
+        {
+            label: getMessage('analysisField.label.status.executing'),
+            value: 'STARTED',
+        },
+        { 
+            label: getMessage('analysisField.label.status.waiting'),
+            value: 'WAITING',
+        },
+        {
+            label: getMessage('analysisField.label.status.error'), 
+            value:'ERROR',
+        },
+    ]
 
     const showSnackbar = (msg, status) => {
         setMsgSnackbar(msg);
@@ -31,11 +79,11 @@ const AlignmentAnalysis = () => {
     }
 
     const analysisActionButton = (status, id) =>{
-        if (status == 'EXECUTION_SUCCEEDED'){
+        if (status == analysisStatus[0].label){
             return <Button onClick={() => navigateTo(location.pathname + '/' + id)}>
                         {getMessage('common.label.details')}
                     </Button>
-        } else if (status == 'WAITING_FOR_EXECUTION' || status == 'IN_EXECUTION'){
+        } else if (status == analysisStatus[1].label || status == analysisStatus[2].label){
             return <Button disabled>
                         {getMessage('common.label.wait')}
                     </Button>
@@ -47,11 +95,11 @@ const AlignmentAnalysis = () => {
     }
 
     const colorStatus = (status) =>{
-        if (status == 'EXECUTION_SUCCEEDED'){
+        if (status == analysisStatus[0].label){
             return 'success.main'
-        } else if (status == 'IN_EXECUTION'){
+        } else if (status == analysisStatus[1].label){
             return 'warning.main'
-        } else if (status == 'WAITING_FOR_EXECUTION') {
+        } else if (status == analysisStatus[2].label) {
             return '#000000'
         } else {
             return 'error.main'
@@ -59,77 +107,317 @@ const AlignmentAnalysis = () => {
     }
 
     const backgroundColorStatus = (status) =>{
-        if (status == 'EXECUTION_SUCCEEDED'){
+        if (status == analysisStatus[0].label){
             return 'success.light'
-        } else if (status == 'IN_EXECUTION'){
+        } else if (status == analysisStatus[1].label){
             return 'warning.light'
-        } else if (status == 'WAITING_FOR_EXECUTION') {
+        } else if (status == analysisStatus[2].label) {
             return 'primary.light'
         } else {
             return 'error.light'
         }
     }
 
-    const onSuccessGetAlignmentAnalysis = (obj) => {
-        if (obj.data.length === 0){
+    const onSuccessGetAnalysis = (obj) => {
+        if (obj.count == 0){
             setInfo(true)
-        } 
+        } else {
+            setInfo(false)
+        }
+
         setColumns([{id: 'id', label: getMessage('alignmentAnalysis.label.id')},
                     {id: 'title', label: getMessage('alignmentAnalysis.label.title')},
                     {id: 'description', label: getMessage('alignmentAnalysisDetails.label.description')},
                     {id: 'type', label: getMessage('alignmentAnalysis.label.type')},
                     {id: 'status', label: getMessage('alignmentAnalysis.label.status')},
                     {id: 'action', label: getMessage('alignmentAnalysis.label.action')}]);
-        setRows(obj.data.map((alnAnalysis, index) => {
+        setRows(obj.results.map((anRes, index) => {
+            let typeObj = analysisType.find(t => t.value === anRes.type).label
+            if (typeObj === undefined) typeObj = '---'
+            let statusObj = analysisStatus.find(s => s.value === anRes.status).label
+            if (statusObj === undefined) statusObj = '---'
+
             return {
                 code: index,
-                id: alnAnalysis.id,
-                title: alnAnalysis.title,
-                description: alnAnalysis.description,
-                type: alnAnalysis.type,
-                status: alnAnalysis.status,
-                action: analysisActionButton(alnAnalysis.status, alnAnalysis.id)
+                id: anRes.id,
+                title: anRes.title,
+                description: anRes.description,
+                type: typeObj,
+                status: statusObj,
+                action: analysisActionButton(statusObj, anRes.id)
                 
             };
         }));
 
-        setTotalPages(Math.ceil(obj.meta.total_pages/15));
+        setTotalPages(Math.ceil(obj.count/15));
         showLoader(false);
     }
   
-    const onFailureGetAlignmentAnalysis = (error) => {
+    const onFailureGetAnalysis = (error) => {
         showSnackbar(getMessage(error.errorDescription), 'error');
         showLoader(false);
+    }
+
+    const handlePaginationChange = (e, page) => {
+        showLoader(true);
+        let url = API_ROUTES.ANALYSIS_LIST;
+        url = url.replace('{analysis_type}', searchFormData.selectFieldType.join(','))
+        + '&title__icontains=' + searchFormData.textFieldTitle
+        + '&status__in=' + searchFormData.selectFieldStatus.join(',')
+        + '&ordering=-id' 
+        + '&page=' + (page);
+
+        makeRequest(url, 'GET', null, onSuccessGetAnalysis, onFailureGetAnalysis);
+    }
+
+    const handleClick = () => {
+        showLoader(true);
+        let url = API_ROUTES.ANALYSIS_LIST;
+        url = url.replace('{analysis_type}', searchFormData.selectFieldType.join(','))
+            + '&title__icontains=' + searchFormData.textFieldTitle
+            + '&status__in=' + searchFormData.selectFieldStatus.join(',')
+            + '&ordering=-id'
+
+        makeRequest(url, 'GET', null, onSuccessGetAnalysis, onFailureGetAnalysis);
+    }
+
+    const handleSearchFormChange = (e) => {
+        setSearchFormData((val) => {
+            return {
+                ...val,
+                [e.target.name]: e.target.value
+            }
+        })
+    }
+
+    const handleReset = (e) => {
+        setSearchFormData({
+            textFieldTitle: "",
+            selectFieldType: [
+                'PAIRWISE_ALIGNMENT',
+                'HOMOLOGY_SEARCH',
+                'TAXONOMY_TREE',
+            ],
+            selectFieldStatus: [
+                'SUCCEEDED',
+                'STARTED',
+                'WAITING',
+                'ERROR',
+            ],
+        })
     }
 
     const onComponentMount = () => {
         showLoader(true);
 
-        let url = API_ROUTES.GET_ANALYSIS_BY_TYPE;
-        url = url.replace('{analysis_type}', 'ALIGNMENT') + '&ordering=-id';
+        let url = API_ROUTES.ANALYSIS_LIST;
 
-        makeRequest(url, 'GET', null, onSuccessGetAlignmentAnalysis, onFailureGetAlignmentAnalysis);
-    }
+        url = url.replace('{analysis_type}', searchFormData.selectFieldType.join(','))
+            + '&title__icontains=' + searchFormData.textFieldTitle
+            + '&status__in=' + searchFormData.selectFieldStatus.join(',')
+            + '&ordering=-id';
 
-    const handlePaginationChange = (e, page) => {
-        showLoader(true);
-        let url = API_ROUTES.GET_ANALYSIS_BY_TYPE;
-        url = url.replace('{analysis_type}', 'ALIGNMENT')  + '&ordering=-id'+ '&page=' + (page);
-
-        makeRequest(url, 'GET', null, onSuccessGetAlignmentAnalysis, onFailureGetAlignmentAnalysis);
+        makeRequest(url, 'GET', null, onSuccessGetAnalysis, onFailureGetAnalysis);
     }
 
     useEffect(() => {
         onComponentMount();
     }, []);
+    
+    return <> 
+        <Box 
+            sx={{
+                mx: 4,
+                mt: 4,
+                px:4,
+                borderBottom: 1,
+            }}>
+            <Paper
+                variant="outlined"
+                elevation={0}
+                sx={{ 
+                    display: 'flex',
+                    flexDirection: 'column',
+                    width: '50%',
+                    mb: 4,
+                    ml: 4,
+                    backgroundColor: '#e5f3f0',
+                    //border: 1,
+                    //borderColor: 'primary.main',
+                    //borderRadius: '0.4rem'
+                }}
+            >
+                <Box
+                    sx={{
+                        mt:2,
+                        ml:4,
+                    }}
+                >
+                    <Typography variant="h4" component="h4" sx={{
+                        color: 'primary.main',
+                        fontWeight: 'bold'
+                    }}>
+                        {getMessage('analysisField.title')}
+                    </Typography>
+                    <Typography variant="h6" component="h6" sx={{
+                        color: 'primary.main',
+                        mt: 1
+                    }}>
+                        {getMessage('analysisField.subtitle')}
+                    </Typography>
+                </Box>
+                <Box
+                    sx={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        width: '100%',
+                    }}
+                >
+                    <Box sx={{
+                        p:1,
+                        px: 4
+                        }}
+                    >
+                        <Typography variant="subtitle2" color="primary.main">
+                            {getMessage('alignmentAnalysis.label.title')}
+                        </Typography>
+                        <TextField 
+                            variant='outlined'
+                            value={searchFormData.textFieldTitle}
+                            name={'textFieldTitle'}
+                            onChange={handleSearchFormChange}
+                            placeholder={getMessage('olatcgAnalysisTable.label.titleAnalysis')}
+                            sx={{
+                                width: '100%'
+                            }}
+                        />
+                    </Box>
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            flexDirection: 'row',
+                            width: '100%',
+                            alignItems: 'center',
+                        }}
+                    >
+                        <Box sx={{
+                            mr: 1,
+                            ml: 4,
+                            width: '50%',
+                        }}
+                        >
+                            <Typography variant="subtitle2" color="primary.main">
+                                {getMessage('alignmentAnalysis.label.type')}
+                            </Typography>
+                            <Select
+                                multiple
+                                value={searchFormData.selectFieldType}
+                                name={'selectFieldType'}
+                                onChange={handleSearchFormChange}
+                                renderValue={(selected) => {
+                                    if (selected.length >= 3) {
+                                        return getMessage('analysisField.label.all')
+                                    } else {
+                                        return selected.join(', ')
+                                    }
+                                }}
+                                sx={{
+                                    width: '100%'
+                                }}
+                            >
+                                {analysisType.map((checkType) => (
+                                    <MenuItem key={checkType.value} value={checkType.value}>
+                                        <Checkbox checked={searchFormData.selectFieldType.includes(checkType.value)}/>
+                                        <ListItemText primary={checkType.label}/>
+                                    </MenuItem>
+                                ))}
+                            </Select>
+                        </Box>
+                        
+                        <Box sx={{
+                            ml: 1,
+                            mr: 4,
+                            width: '50%',
+                        }}
+                        >
+                            <Typography variant="subtitle2" color="primary.main">
+                                {getMessage('alignmentAnalysis.label.status')}
+                            </Typography>
+                            <Select
+                                multiple
+                                value={searchFormData.selectFieldStatus}
+                                name={'selectFieldStatus'}
+                                onChange={handleSearchFormChange}
+                                renderValue={(selected) => {
+                                    if (selected.length >= 4){
+                                        return getMessage('analysisField.label.all')
+                                    } else {
+                                        return selected.join(', ')
+                                    }
+                                }}
+                                sx={{
+                                    width:'100%'
+                                }}
+                            >
+                                {analysisStatus.map((checkStatus) => (
+                                    <MenuItem key={checkStatus.value} value={checkStatus.value}>
+                                        <Checkbox checked={searchFormData.selectFieldStatus.includes(checkStatus.value)} />
+                                        <ListItemText primary={checkStatus.label} />
+                                    </MenuItem>
+                                ))}
+                            </Select>
+                        </Box>
+                    </Box>
+                </Box>
+                <Box 
+                    sx={{
+                        display: 'flex',
+                        flexDirection: 'row',
+                        m: 2,
+                        ml: 4,
+                        mr: 'auto',
+                    }}
+                >
 
-    if(location.pathname === '/analysis/alignment'){
-        
-        return <> 
-         
+                    {/* Submit button */}
+                    <Button 
+                        type="submit" 
+                        size="large"
+                        onClick={() => handleClick()}
+                        sx={{
+                            mr: 2,
+                            alignSelf: 'center',
+                            backgroundColor: 'primary.main',
+                            color: 'primary.contrastText',
+                            '&:hover': {
+                                cursor: 'pointer'
+                            }
+                            }}
+                    >
+                        {getMessage('experimentField.label.submit')}
+                    </Button>
+
+                    {/* Reset button */}
+                    <Button 
+                        type="reset" 
+                        size="large" 
+                        onClick={() => handleReset()} 
+                        sx={{
+                        alignSelf: 'center',
+                        backgroundColor: 'primary.main',
+                        color: 'primary.contrastText',
+                        '&:hover': {
+                            cursor: 'pointer'
+                        }
+                    }}>
+                        {getMessage('experimentField.label.reset')}
+                    </Button>
+                </Box>
+
+            </Paper>
             <Box sx={{px: 4, pb: 8}}>{info ? <OlatcgNodata />: 
                 <Paper sx={{ width: '100%', overflow: 'hidden', bgcolor: 'primary.light' }}>
-                    <TableContainer sx={{ maxHeight: '60vh' }}>
+                    <TableContainer sx={{ maxHeight: '80vh' }}>
                         <Table stickyHeader aria-label="sticky table" >
                         
                             <TableHead>
@@ -204,17 +492,16 @@ const AlignmentAnalysis = () => {
                     />
                 </Box>
             </Box>
-            <OlatcgSnackbar
-                isOpened={isSnackbarOpened} 
-                onClose={() => openSnackbar(false)}
-                status={statusSnackbar}
-                msg={msgSnackbar} 
-            />
-            <OlatcgLoader show={isLoading}/>
-        </>
-    }
-
-    return <Outlet />
+        </Box>
+        <OlatcgSnackbar
+            isOpened={isSnackbarOpened} 
+            onClose={() => openSnackbar(false)}
+            status={statusSnackbar}
+            msg={msgSnackbar} 
+        />
+        <OlatcgLoader show={isLoading}/>
+    </>
+    
 };
 
 export { AlignmentAnalysis };

--- a/src/routes/AppRoutes.js
+++ b/src/routes/AppRoutes.js
@@ -31,15 +31,15 @@ export default function AppRoutes(){
                 <Route path="homology" element={<Homology />} />
             </Route>
             <Route path="experiment" element={<Experiment />} />
-            <Route path="analysis" element={<Analysis />}>
-                <Route path="alignment" element={<AlignmentAnalysis />}>
+            <Route path="analysis" element={<AlignmentAnalysis/>}>
+                <Route path="alignment">
                     <Route path=":idAnalysis" element={<AlignmentAnalysisDetails/>} />
                 </Route>
-                <Route path="homology" element={<HomologyAnalysis />} >
+                <Route path="homology">
                     <Route path='tree/:idAnalysis'element={<PhyloTree />}/>
                     <Route path=":idAnalysis" element={<HomologyAnalysisDetails />} />
                 </Route>
-                <Route path="phylogeneticTree" element={<PhylogeneticTreeAnalysis/>}>
+                <Route path="phylogeneticTree">
                     <Route path=':idAnalysis'element={<PhyloTree />}/>
                 </Route>
             </Route>

--- a/src/routes/Routes.js
+++ b/src/routes/Routes.js
@@ -1,7 +1,7 @@
 var BASE_URL = process.env.REACT_APP_BACKEND_URL || 'http://localhost:8000';
 
 //var API_BASE_PATH = BASE_URL + '/v1/api';
-var API_BASE_PATH = 'https://spica.eic.cefet-rj.br/v3/olatcg-backend';
+//var API_BASE_PATH = 'https://spica.eic.cefet-rj.br/v3/olatcg-backend';
 var API_BASE_PATH = BASE_URL + '/v3/olatcg-backend'; 
 
 //BACKEND ROUTES
@@ -12,6 +12,9 @@ const API_ROUTES = {
     ANALYSIS_FROM_EXPERIMENT_ID: API_BASE_PATH + '/experiment/{experiment_id}/analysis/',
     GET_EXPERIMENT: API_BASE_PATH + '/experiment/?ordering=-id',
     GET_EXPERIMENT_BY_ID: API_BASE_PATH + '/experiment/{experiment_id}/',
+
+    //NEW
+    ANALYSIS_LIST: API_BASE_PATH + '/experiment/1/analysis/?type__in={analysis_type}',
 
     //ALIGNMENT
     ALIGN: API_BASE_PATH + '/analysis/{analysis_id}/alignment/',

--- a/src/services/MessageService.js
+++ b/src/services/MessageService.js
@@ -135,15 +135,16 @@ var data_en = {
     'tutorials.contentList.listItem.label.tutorials'            : 'How to Use OLATCG',
 
     /**ANALYSIS FILTER FIELDS*/
-    'analysisField.title'                      : 'Search your analysis or your experiment based on the filter below',
+    'analysisField.title'                      : 'Explore your analyses',
+    'analysisField.subtitle'                   : 'Search your analyses based on the filter below',
     'analysisField.label.experiment.id'        : 'Experiment ID',
     'analysisField.label.experiment.title'     : 'Experiment Title',
     'analysisField.label.analysis.id'          : 'Analysis ID',
     'analysisField.label.analysis.title'       : 'Analysis Title',
     'analysisField.label.type'                 : 'Type',
-    'analysisField.label.type.alignment'       : 'ALIGNMENT',
-    'analysisField.label.type.homology'        : 'HOMOLOGY',
-    'analysisField.label.type.phyloTree'       : 'PHYLOGENETIC TREE',
+    'analysisField.label.type.alignment'       : 'Alignment',
+    'analysisField.label.type.homology'        : 'Homology',
+    'analysisField.label.type.phyloTree'       : 'Phylogenetic Tree',
     'analysisField.label.status'               : 'Status',
     'analysisField.label.status.success'       : 'Execution succeded',
     'analysisField.label.status.waiting'       : 'Waiting for execution',
@@ -151,6 +152,7 @@ var data_en = {
     'analysisField.label.status.error'         : 'Error in execution',
     'analysisField.label.submit'               : 'Search',
     'analysisField.label.reset'                : 'Reset',
+    'analysisField.label.all'                  : 'All available',
 
     /**ANALYSIS TABLE - ALL TYPES */
     'olatcgAnalysisTable.label.idAnalysis'              : 'Analysis ID',
@@ -520,7 +522,8 @@ var data = {
     'tutorials.contentList.listItem.label.tutorials'            : 'Como usar o OLATCG',
 
      /**ANALYSIS FILTER FIELDS*/
-    'analysisField.title'                      : 'Pesquise sua análise ou seu experimento baseado nos filtros abaixo',
+    'analysisField.title'                   : 'Explore suas análises',
+    'analysisField.subtitle'                   : 'Pesquise sua análise com ajuda dos filtros abaixo',
     'analysisField.label.experiment.id'        : 'ID do experimento',
     'analysisField.label.experiment.title'     : 'Título do experimento',
     'analysisField.label.analysis.id'          : 'ID da análise',
@@ -536,6 +539,7 @@ var data = {
     'analysisField.label.status.error'         : 'Erro na execução',
     'analysisField.label.submit'               : 'Pesquisar',
     'analysisField.label.reset'                : 'Limpar',
+    'analysisField.label.all'                  : 'Todos',
 
     /**ANALYSIS TABLE - ALL TYPES */
     'olatcgAnalysisTable.label.idAnalysis'              : 'ID da Análise',


### PR DESCRIPTION
Referring to the issue [69](https://github.com/LuizMVB/olatcg-frontend/issues/69#issue-3444995809).

Adaptations were made to previous pages and routes so analyzes can be viewed and filtered through special fields. Currently the analyzes shown correlate only for Experiment ID 1.